### PR TITLE
Fix finding smi tool for Gentoo

### DIFF
--- a/patch-fbc.sh
+++ b/patch-fbc.sh
@@ -243,6 +243,7 @@ get_supported_versions () {
 }
 
 patch_common () {
+    PATH=$PATH:/opt/bin
     NVIDIA_SMI="$(command -v nvidia-smi || true)"
     if [[ ! "$NVIDIA_SMI" ]] ; then
         echo 'nvidia-smi utility not found. Probably driver is not installed.'

--- a/patch.sh
+++ b/patch.sh
@@ -317,6 +317,7 @@ get_supported_versions () {
 }
 
 patch_common () {
+    PATH=$PATH:/opt/bin
     NVIDIA_SMI="$(command -v nvidia-smi || true)"
     if [[ ! "$NVIDIA_SMI" ]] ; then
         echo 'nvidia-smi utility not found. Probably driver is not installed.'


### PR DESCRIPTION
The smi tool for me is located in /opt/bin when running Gentoo, and for some reason that folder isn't included in the path when ran as su